### PR TITLE
Fixed connectionSize Limit

### DIFF
--- a/EEIP.NET/EIPClient.cs
+++ b/EEIP.NET/EIPClient.cs
@@ -435,7 +435,7 @@ namespace Sres.Net.EEIP
             connectionType = (byte)T_O_ConnectionType; //1=Multicast, 2=P2P
             priority = (byte)T_O_Priority;
             variableLength = T_O_VariableLength;
-            connectionSize = (byte)(T_O_Length  + t_o_headerOffset);
+            connectionSize = Convert.ToUInt16(T_O_Length + t_o_headerOffset);
             NetworkConnectionParameters = (UInt16)((UInt16)(connectionSize & 0x1FF) | ((Convert.ToUInt16(variableLength)) << 9) | ((priority & 0x03) << 10) | ((connectionType & 0x03) << 13) | ((Convert.ToUInt16(redundantOwner)) << 15));
             if (largeForwardOpen)
                 NetworkConnectionParameters = (UInt32)((uint)(connectionSize & 0xFFFF) | ((Convert.ToUInt32(variableLength)) << 25) | (uint)((priority & 0x03) << 26) | (uint)((connectionType & 0x03) << 29) | ((Convert.ToUInt32(redundantOwner)) << 31));


### PR DESCRIPTION
T_O_Length is a UInt16, but when adding it and the t_o_headerOffset variables together to get the connectionSize, it was typecast to a byte. When working with a device that returns 496 bytes, an implicit connection could not be established due to this. The conversion was changed to a UInt16 to allow for all 9 bits.

I think issue #19 may be related to this.